### PR TITLE
fix(jira-api): Add index file for jira reports

### DIFF
--- a/packages/jira-reports/package.json
+++ b/packages/jira-reports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jira-apis/jira-reports",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "./dist/index.js",
   "type": "module",
   "scripts": {

--- a/packages/jira-reports/src/index.ts
+++ b/packages/jira-reports/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./CapexReport.js"


### PR DESCRIPTION
Adds an index file for `jira-reports` so you can import the capex report. 